### PR TITLE
Print attitude and disable heading message

### DIFF
--- a/ArduPilotDriver.py
+++ b/ArduPilotDriver.py
@@ -79,7 +79,6 @@ async def async_main():
         "orientation": curr_time,
         "heading": curr_time
     }
-    last_data = {}
 
     # From M8N documentation:
     # If unable to preform normal compass calibration "compass dance" for any reason,

--- a/ArduPilotDriver.py
+++ b/ArduPilotDriver.py
@@ -106,7 +106,7 @@ async def async_main():
                 else:
                     pitch_deg = attitude.pitch * 180 / math.pi
                     roll_deg = attitude.roll * 180 / math.pi
-                    print(f"\33[2K\rroll={roll_deg: 4.0f}, pitch={pitch_deg: 4.0f}")
+                    print(f"\33[2K\rroll={roll_deg: 4.0f}, pitch={pitch_deg: 4.0f}", end="")
                 last_data_send_times["orientation"] = curr_time
                 asyncio.run(send_orientation_message(websocket, attitude.roll, attitude.pitch, attitude.yaw))
         
@@ -129,7 +129,7 @@ async def async_main():
             print(e)
             ardupilot.remove_attribute_listener("location.global_frame", gps_callback)
             ardupilot.remove_attribute_listener("attitude", orientation_callback)
-            ardupilot.remove_attribute_listener("heading", heading_callback)
+            # ardupilot.remove_attribute_listener("heading", heading_callback)
             continue
 
 def main():

--- a/ArduPilotDriver.py
+++ b/ArduPilotDriver.py
@@ -6,6 +6,7 @@ import asyncio
 import websockets
 import json
 import argparse
+import math
 
 # This if is required because dronekit is not up to date for python 3.10
 if sys.version_info.major == 3 and sys.version_info.minor >= 10:
@@ -78,6 +79,7 @@ async def async_main():
         "orientation": curr_time,
         "heading": curr_time
     }
+    last_data = {}
 
     # From M8N documentation:
     # If unable to preform normal compass calibration "compass dance" for any reason,
@@ -101,6 +103,10 @@ async def async_main():
             if curr_time >= last_data_send_times["orientation"] + 1./args.frequency:
                 if args.debug:
                     print(attitude)
+                else:
+                    pitch_deg = attitude.pitch * 180 / math.pi
+                    roll_deg = attitude.roll * 180 / math.pi
+                    print(f"\33[2K\rroll={roll_deg: 4.0f}, pitch={pitch_deg: 4.0f}")
                 last_data_send_times["orientation"] = curr_time
                 asyncio.run(send_orientation_message(websocket, attitude.roll, attitude.pitch, attitude.yaw))
         

--- a/ArduPilotDriver.py
+++ b/ArduPilotDriver.py
@@ -114,7 +114,7 @@ async def async_main():
         
         ardupilot.add_attribute_listener("location.global_frame", gps_callback)
         ardupilot.add_attribute_listener("attitude", orientation_callback)
-        ardupilot.add_attribute_listener("heading", heading_callback)
+        # ardupilot.add_attribute_listener("heading", heading_callback)
 
         try:
             while True:


### PR DESCRIPTION
This PR adds some changes from CIRC. The heading message isn't expected by the rover, so it was creating a lot of garbage in the logs. And the attitude logging was put as a backup.