### PR TITLE
Fix reconnect behavior when rover code shuts down

### DIFF
--- a/ArduPilotDriver.py
+++ b/ArduPilotDriver.py
@@ -119,7 +119,7 @@ async def async_main():
                 ardupilot.add_attribute_listener("attitude", orientation_callback)
 
                 try:
-                    asyncio.get_event_loop().run_forever()
+                    await asyncio.Future()
                 except websockets.ConnectionClosed as e:
                     print(e)
                     ardupilot.remove_attribute_listener("location.global_frame", gps_callback)


### PR DESCRIPTION
The default reconnect behavior is with exponential backoff, which means it could take several minutes to reconnect after the rover code is started again. This manually implements retrying with a fixed delay of 3 seconds, so it'll be much faster.

Also, since we get yaw from the orientation packet, this removes the heading code that was commented out since we don't need it.